### PR TITLE
Use the new `:focus` notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ solution than trying to run Rspec from within the context of SublimeText.
 
 ## Features
 * searches for closest defined spec
-* adds `focus: true` configuration to closest `it`, `context`, or `describe` block
+* adds `:focus` configuration to closest `it`, `context`, or `describe` block
 * shortcut for toggling focus on currently highlighted spec (`CMD+ALT+CTRL+F`)
 * re-runnable to remove the focus keywords after complete
-* clears all `focus: true` tags from the current file
+* clears all `:focus` tags from the current file
 * shortcut for clearing focus tags on current file (`CMD+ALT+CTRL+C`)
+* ability to use the "old style" `focus: true` configuration
 
 ## Installation
 
@@ -24,13 +25,16 @@ Install via the great [Package Control Plugin Manager](https://sublime.wbond.net
 
 ## Usage
 
-**Add `focus: true` tag**
+**Add `:focus` tag**
 * Open control panel (ex: CMD+SHIFT+P)
 * select "Toggle Focus on currently selected spec" command
-* `focus: true` will be automatically added to the currently selected spec
+* `:focus` will be automatically added to the currently selected spec
 * Re-run command to remove the focus keywords
 
-**Clear all `focus: true` tags from the current file**
+**Clear all `:focus` tags from the current file**
 * Open control panel (ex: CMD+SHIFT+P)
 * select "Remove all focus tags from current file" command
-* all instances of `focus: true` will be removed from the current file
+* all instances of `:focus` will be removed from the current file
+
+**Use `focus: true` instead of the new `:focus` syntax**
+* Add `"spec_focus_old_style": true` to your preferences file

--- a/SpecFocuser.py
+++ b/SpecFocuser.py
@@ -18,30 +18,40 @@ class SpecFocusCommand(sublime_plugin.TextCommand):
     while current_line.begin() >= 0:
       line_text = self.view.substr(current_line)
 
-      focused_spec_matcher = '(it|describe|context|scenario).+, focus: true\s+do'
+      focused_spec_matcher = '(it|describe|context|scenario).+, ' + SpecFocusSettings.focus_string() + '\s+do'
       match = re.search(focused_spec_matcher, line_text)
       if match:
         print("Removing focused spec definition...")
-        self.view.replace(edit, current_line, re.sub(', focus: true ', ' ', line_text))
+        self.view.replace(edit, current_line, re.sub(', ' + SpecFocusSettings.focus_string() + ' ', ' ', line_text))
         break
 
       spec_matcher = '(it|describe|context|scenario)\s?(.*)\sdo'
       match = re.search(spec_matcher, line_text)
       if match:
         print("Adding focused spec definition...")
-        self.view.replace(edit, current_line, re.sub(spec_matcher, r'\1 \2, focus: true do', line_text))
+        self.view.replace(edit, current_line, re.sub(spec_matcher, r'\1 \2, ' + SpecFocusSettings.focus_string() + ' do', line_text))
         break
 
       selection = sublime.Region(current_line.begin() - 1, current_line.begin() - 1)
       current_line = self.view.line(selection)
 
-# clear all "focus: true" tags from the current file
+# clear all ":focus" tags from the current file
 class ClearSpecFocusCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         print("Clearing all focus tags...")
         view = self.view
         matches = []
-        results = view.find_all(", focus: true", sublime.IGNORECASE, "", matches)
+        results = view.find_all(", " + SpecFocusSettings.focus_string(), sublime.IGNORECASE, "", matches)
         for i, thisregion in reversed(list(enumerate(results))):
           view.replace(edit, thisregion, matches[i])
+
+class SpecFocusSettings():
+    @classmethod
+    def focus_string(cls):
+        s = sublime.load_settings('Preferences.sublime-settings')
+
+        if s.get('spec_focus_old_style', False):
+            return 'focus: true'
+        else:
+            return ':focus'
 


### PR DESCRIPTION
Use the new :focus syntax by default and allow users to still use the old syntax through their preferences.