### PR TITLE
Adding `feature` to the list of recognized blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ solution than trying to run Rspec from within the context of SublimeText.
 
 ## Features
 * searches for closest defined spec
-* adds `:focus` configuration to closest `it`, `context`, or `describe` block
+* adds `:focus` configuration to closest `it`, `context`, `feature`, or `describe` block
 * shortcut for toggling focus on currently highlighted spec (`CMD+ALT+CTRL+F`)
 * re-runnable to remove the focus keywords after complete
 * clears all `:focus` tags from the current file

--- a/SpecFocuser.py
+++ b/SpecFocuser.py
@@ -18,14 +18,14 @@ class SpecFocusCommand(sublime_plugin.TextCommand):
     while current_line.begin() >= 0:
       line_text = self.view.substr(current_line)
 
-      focused_spec_matcher = '(it|describe|context|scenario).+, ' + SpecFocusSettings.focus_string() + '\s+do'
+      focused_spec_matcher = '(it|describe|context|scenario|feature).+, ' + SpecFocusSettings.focus_string() + '\s+do'
       match = re.search(focused_spec_matcher, line_text)
       if match:
         print("Removing focused spec definition...")
         self.view.replace(edit, current_line, re.sub(', ' + SpecFocusSettings.focus_string() + ' ', ' ', line_text))
         break
 
-      spec_matcher = '(it|describe|context|scenario)\s?(.*)\sdo'
+      spec_matcher = '(it|describe|context|scenario|feature)\s?(.*)\sdo'
       match = re.search(spec_matcher, line_text)
       if match:
         print("Adding focused spec definition...")


### PR DESCRIPTION
In addition to `it`, `context`, and `describe`, rspec also allows the use of `feature` blocks. The fix seems simple enough...